### PR TITLE
Some minor config updates to help get repo running

### DIFF
--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -59,7 +59,7 @@ export default {
   apollo: {
     clientConfigs: {
       default: {
-        httpEndpoint: process.env.API_URL + "/graphql"
+        httpEndpoint: (process.env.API_URL || "http://localhost:1337") + "/graphql"
       }
     }
   },

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -70,6 +70,19 @@ export default {
     /*
      ** You can extend webpack config here
      */
-    extend(config, ctx) {}
+    extend(config, ctx) {},
+    babel: {
+      presets({ isServer }) {
+        return [
+          [
+            require.resolve('@nuxt/babel-preset-app'),
+            {
+              buildTarget: isServer ? 'server' : 'client',
+              corejs: { version: 3 }
+            }
+          ]
+        ]
+      }
+    }
   }
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,9 @@
     "nuxt": "^2.0.0",
     "uikit": "^3.2.3"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@babel/runtime-corejs3": "^7.9.6",
+    "core-js": "^3.6.5"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
Thanks for the great starter project.

I ran into two issues that I have resolved. I believe other users may also have the same type of problems.

1. I was getting various errors related to core-js dependencies loading when the nuxt attempted to start.
2. I also was getting an error related to the apollo client making request since the nuxt.config.js was set to use `process.env.API_URL` .... If you don't set by default it will send `undefined` and cause the Nuxt app to not load and produces an error. I have added an `||` to use the default Strapi endpoint `http://localhost:1337`. This is the same thing already being done on Line 7 of nuxt.config.js (where the `env.strapiBaseUri` is configured.

If you feel this PR is not relevant, then we can just trash it.

Thank you!